### PR TITLE
feat(chat-ui): implement custom window rounded corner

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,7 +85,6 @@
     <PackageVersion Include="Avalonia.Headless" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Headless.NUnit" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="$(AvaloniaEditVersion)" />
-    <PackageVersion Include="ClassicDiagnostics.Avalonia" Version="0.0.2-preview" />
     <PackageVersion Include="LiveMarkdown.Avalonia" Version="$(LiveMarkdownVersion)" />
     <PackageVersion Include="LiveMarkdown.Avalonia.Math" Version="$(LiveMarkdownVersion)" />
     <PackageVersion Include="LiveMarkdown.Avalonia.Mermaid" Version="$(LiveMarkdownVersion)" />

--- a/Everywhere.Linux.slnx
+++ b/Everywhere.Linux.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/3rd/">
+    <Project Path="3rd/ClassicDiagnostics.Avalonia/src/ClassicDiagnostics.Avalonia.csproj" />
     <Project Path="3rd/shad-ui/src/ShadUI/ShadUI.csproj" />
   </Folder>
   <Folder Name="/3rd/MessagePack/">
@@ -25,6 +26,7 @@
     <Project Path="patches/Everywhere.Patches.Avalonia.Controls/Everywhere.Patches.Avalonia.Controls.csproj" />
     <Project Path="patches/Everywhere.Patches.Avalonia.Native/Everywhere.Patches.Avalonia.Native.csproj" />
     <Project Path="patches/Everywhere.Patches.AvaloniaEdit/Everywhere.Patches.AvaloniaEdit.csproj" />
+    <Project Path="patches/Everywhere.Patches.Contracts/Everywhere.Patches.Contracts.csproj" />
     <Project Path="patches/Everywhere.Patches.SemanticKernel/Everywhere.Patches.SemanticKernel.csproj" />
   </Folder>
   <Project Path="src/Everywhere.Abstractions/Everywhere.Abstractions.csproj" />

--- a/Everywhere.Mac.slnx
+++ b/Everywhere.Mac.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/3rd/">
+    <Project Path="3rd/ClassicDiagnostics.Avalonia/src/ClassicDiagnostics.Avalonia.csproj" />
     <Project Path="3rd/shad-ui/src/ShadUI/ShadUI.csproj" />
   </Folder>
   <Folder Name="/3rd/MessagePack/">
@@ -25,6 +26,7 @@
     <Project Path="patches/Everywhere.Patches.Avalonia.Controls/Everywhere.Patches.Avalonia.Controls.csproj" />
     <Project Path="patches/Everywhere.Patches.Avalonia.Native/Everywhere.Patches.Avalonia.Native.csproj" />
     <Project Path="patches/Everywhere.Patches.AvaloniaEdit/Everywhere.Patches.AvaloniaEdit.csproj" />
+    <Project Path="patches/Everywhere.Patches.Contracts/Everywhere.Patches.Contracts.csproj" />
     <Project Path="patches/Everywhere.Patches.SemanticKernel/Everywhere.Patches.SemanticKernel.csproj" />
   </Folder>
   <Project Path="src/Everywhere.Abstractions/Everywhere.Abstractions.csproj" />

--- a/Everywhere.Windows.slnx
+++ b/Everywhere.Windows.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/3rd/">
+    <Project Path="3rd/ClassicDiagnostics.Avalonia/src/ClassicDiagnostics.Avalonia.csproj" />
     <Project Path="3rd/EverythingNetCore/EverythingNet/EverythingNet.csproj" />
     <Project Path="3rd/shad-ui/src/ShadUI/ShadUI.csproj" />
   </Folder>
@@ -25,7 +26,9 @@
     <Project Path="patches/Everywhere.BuildTask.Patcher/Everywhere.BuildTask.Patcher.csproj" />
     <Project Path="patches/Everywhere.Patches.Avalonia.Controls/Everywhere.Patches.Avalonia.Controls.csproj" />
     <Project Path="patches/Everywhere.Patches.Avalonia.Native/Everywhere.Patches.Avalonia.Native.csproj" />
+    <Project Path="patches/Everywhere.Patches.Avalonia.Win32/Everywhere.Patches.Avalonia.Win32.csproj" />
     <Project Path="patches/Everywhere.Patches.AvaloniaEdit/Everywhere.Patches.AvaloniaEdit.csproj" />
+    <Project Path="patches/Everywhere.Patches.Contracts/Everywhere.Patches.Contracts.csproj" />
     <Project Path="patches/Everywhere.Patches.SemanticKernel/Everywhere.Patches.SemanticKernel.csproj" />
   </Folder>
   <Project Path="src/Everywhere.Abstractions/Everywhere.Abstractions.csproj" />

--- a/Everywhere.slnx
+++ b/Everywhere.slnx
@@ -65,7 +65,9 @@
     <Project Path="patches/Everywhere.BuildTask.Patcher/Everywhere.BuildTask.Patcher.csproj" />
     <Project Path="patches/Everywhere.Patches.Avalonia.Controls/Everywhere.Patches.Avalonia.Controls.csproj" />
     <Project Path="patches/Everywhere.Patches.Avalonia.Native/Everywhere.Patches.Avalonia.Native.csproj" />
+    <Project Path="patches/Everywhere.Patches.Avalonia.Win32/Everywhere.Patches.Avalonia.Win32.csproj" />
     <Project Path="patches/Everywhere.Patches.AvaloniaEdit/Everywhere.Patches.AvaloniaEdit.csproj" />
+    <Project Path="patches/Everywhere.Patches.Contracts/Everywhere.Patches.Contracts.csproj" />
     <Project Path="patches/Everywhere.Patches.SemanticKernel/Everywhere.Patches.SemanticKernel.csproj" />
   </Folder>
   <Folder Name="/Targets/">

--- a/patches/Everywhere.BuildTask.Patcher/WeaveAssembliesTask.cs
+++ b/patches/Everywhere.BuildTask.Patcher/WeaveAssembliesTask.cs
@@ -1,4 +1,6 @@
 using System.Text.RegularExpressions;
+using System.Reflection;
+using System.Runtime.Loader;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using MonoMod;
@@ -125,7 +127,44 @@ public partial class WeaveAssembliesTask : Task
                         modder.ReadMod(patchDllPath);
                         modder.MapDependencies();
 
-                        modder.AutoPatch();
+                        var ruleAssemblyDirectories = depDirs
+                            .Append(Path.GetDirectoryName(typeof(MonoModder).Assembly.Location))
+                            .Where(path => !string.IsNullOrWhiteSpace(path))
+                            .OfType<string>()
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .ToArray();
+                        Assembly? ResolveRuleAssembly(AssemblyLoadContext _, AssemblyName assemblyName)
+                        {
+                            var alreadyLoaded = AppDomain.CurrentDomain
+                                .GetAssemblies()
+                                .FirstOrDefault(assembly =>
+                                    string.Equals(assembly.GetName().Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase));
+                            if (alreadyLoaded != null)
+                            {
+                                return alreadyLoaded;
+                            }
+
+                            foreach (var directory in ruleAssemblyDirectories)
+                            {
+                                var candidate = Path.Combine(directory, $"{assemblyName.Name}.dll");
+                                if (File.Exists(candidate))
+                                {
+                                    return AssemblyLoadContext.Default.LoadFromAssemblyPath(candidate);
+                                }
+                            }
+
+                            return null;
+                        }
+
+                        AssemblyLoadContext.Default.Resolving += ResolveRuleAssembly;
+                        try
+                        {
+                            modder.AutoPatch();
+                        }
+                        finally
+                        {
+                            AssemblyLoadContext.Default.Resolving -= ResolveRuleAssembly;
+                        }
                         modder.Write();
 
                         Log.LogMessage(MessageImportance.High, $"[Patcher] Wrote patched DLL: {outputDllPath}");

--- a/patches/Everywhere.Patches.Avalonia.Win32/DirectCompositionStubs.cs
+++ b/patches/Everywhere.Patches.Avalonia.Win32/DirectCompositionStubs.cs
@@ -1,0 +1,145 @@
+using System.Runtime.InteropServices;
+using Avalonia.OpenGL.Egl;
+using Everywhere.Patches.Contracts.Interop;
+using MicroCom.Runtime;
+using MonoMod;
+using Vortice.DirectComposition;
+
+// Avalonia's DirectComposition bindings are internal. These declarations provide
+// only the members consumed by the patch and are relinked to Avalonia's bindings
+// when MonoMod weaves the target assembly.
+// ReSharper disable once CheckNamespace
+namespace Avalonia.Win32.DComposition;
+
+[MonoModIgnore]
+internal interface IDCompositionDevice2 : IUnknown;
+
+[MonoModIgnore]
+internal interface IDCompositionVisual : IUnknown
+{
+    void SetClip_IDCompositionClip(IntPtr clip);
+}
+
+[MonoModPatch("Avalonia.Win32.DComposition.DirectCompositedWindow")]
+internal class patch_DirectCompositedWindow : IDisposable
+{
+    [MonoModIgnore]
+    private readonly DirectCompositionShared _shared = null!;
+
+    [MonoModIgnore]
+    public extern EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo WindowInfo { get; }
+
+    [MonoModIgnore]
+    private readonly IDCompositionVisual _container = null!;
+
+    [MonoModIgnore]
+    private readonly IDCompositionDevice2 _device = null!;
+
+    private IDCompositionRectangleClip? _everywhereCornerClip;
+    private PixelSize _everywhereCornerSize;
+    private double _everywhereCornerScaling;
+    private float _everywhereCornerRadius = float.NaN;
+
+    private static bool TryGetCornerRadius(
+        EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo windowInfo,
+        out double radius)
+    {
+        // ReSharper disable once SuspiciousTypeConversion.Global
+        if (windowInfo is IWindowCornerRadiusFeature feature)
+            return feature.TryGetEffectiveCornerRadius(out radius);
+
+        radius = 0;
+        return false;
+    }
+
+    // The wrapper below must not use MonoModReplace: MonoMod needs to preserve
+    // Avalonia's implementation under this orig_ name before applying the wrapper.
+    public extern IDisposable orig_BeginTransaction();
+
+    public IDisposable BeginTransaction()
+    {
+        var transaction = orig_BeginTransaction();
+        try
+        {
+            UpdateEverywhereCornerClip();
+            return transaction;
+        }
+        catch
+        {
+            transaction.Dispose();
+            throw;
+        }
+    }
+
+    private void UpdateEverywhereCornerClip()
+    {
+        if (!TryGetCornerRadius(WindowInfo, out var logicalRadius))
+            return;
+
+        var size = WindowInfo.Size;
+        var scaling = WindowInfo.Scaling;
+        var radius = (float)(logicalRadius * scaling);
+        var needsCreation = _everywhereCornerClip is null;
+        var sizeChanged = _everywhereCornerSize != size;
+        var scaleChanged = Math.Abs(_everywhereCornerScaling - scaling) > double.Epsilon;
+        var radiusChanged = float.IsNaN(_everywhereCornerRadius) || Math.Abs(_everywhereCornerRadius - radius) > float.Epsilon;
+
+        if (needsCreation)
+        {
+            // Keep the clip in the DirectComposition tree; SetWindowRgn would lose antialiasing.
+            var devicePointer = _device.GetNativeIntPtr();
+            Marshal.AddRef(devicePointer);
+            using var device = new Vortice.DirectComposition.IDCompositionDevice2(devicePointer);
+            _everywhereCornerClip = device.CreateRectangleClip();
+        }
+
+        var clip = _everywhereCornerClip;
+        if (clip is null)
+            return;
+
+        if (needsCreation || sizeChanged || scaleChanged)
+        {
+            clip.SetLeft(0);
+            clip.SetTop(0);
+            clip.SetRight(size.Width);
+            clip.SetBottom(size.Height);
+        }
+
+        if (needsCreation || radiusChanged)
+        {
+            clip.SetTopLeftRadiusX(radius);
+            clip.SetTopLeftRadiusY(radius);
+            clip.SetTopRightRadiusX(radius);
+            clip.SetTopRightRadiusY(radius);
+            clip.SetBottomLeftRadiusX(radius);
+            clip.SetBottomLeftRadiusY(radius);
+            clip.SetBottomRightRadiusX(radius);
+            clip.SetBottomRightRadiusY(radius);
+        }
+
+        if (needsCreation)
+            _container.SetClip_IDCompositionClip(clip.NativePointer);
+
+        _everywhereCornerSize = size;
+        _everywhereCornerScaling = scaling;
+        _everywhereCornerRadius = radius;
+    }
+
+    // Keep Avalonia's original disposal path so its DirectComposition objects are released.
+    public extern void orig_Dispose();
+
+    public void Dispose()
+    {
+        lock (_shared.SyncRoot)
+        {
+            if (_everywhereCornerClip is not null)
+            {
+                _container.SetClip_IDCompositionClip(IntPtr.Zero);
+                _everywhereCornerClip.Dispose();
+                _everywhereCornerClip = null;
+            }
+
+            orig_Dispose();
+        }
+    }
+}

--- a/patches/Everywhere.Patches.Avalonia.Win32/DwmStubs.cs
+++ b/patches/Everywhere.Patches.Avalonia.Win32/DwmStubs.cs
@@ -1,0 +1,18 @@
+using MonoMod;
+
+// Avalonia's DWM enum is internal. This declaration supplies its compile-time shape and is
+// relinked to the target assembly's enum when MonoMod weaves the patch.
+// ReSharper disable once CheckNamespace
+namespace Avalonia.Win32.Interop;
+
+[MonoModIgnore]
+internal static class UnmanagedMethods
+{
+    [MonoModIgnore]
+    internal enum DwmNCRenderingPolicy : uint
+    {
+        DWMNCRP_USEWINDOWSTYLE,
+        DWMNCRP_DISABLED,
+        DWMNCRP_ENABLED
+    }
+}

--- a/patches/Everywhere.Patches.Avalonia.Win32/Everywhere.Patches.Avalonia.Win32.csproj
+++ b/patches/Everywhere.Patches.Avalonia.Win32/Everywhere.Patches.Avalonia.Win32.csproj
@@ -1,13 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <NoWarn>CA1822,CS0436,CS0626,CS0649</NoWarn>
+    <NoWarn>$(NoWarn),CA1822,CS0436,CS0626,CS0649</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MonoMod.Patcher" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" />
-    <PackageReference Include="AvaloniaEdit.TextMate" />
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <!-- The application already carries this package for its DirectComposition integration. -->
+    <PackageReference Include="Vortice.DirectComposition" />
     <PackageReference Include="IgnoresAccessChecksToGenerator">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -15,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <IgnoresAccessChecksTo Include="AvaloniaEdit" />
+    <IgnoresAccessChecksTo Include="Avalonia.Win32" />
   </ItemGroup>
 
   <ItemGroup>

--- a/patches/Everywhere.Patches.Avalonia.Win32/MonoModRules.cs
+++ b/patches/Everywhere.Patches.Avalonia.Win32/MonoModRules.cs
@@ -1,0 +1,89 @@
+using System.Collections;
+using System.Reflection;
+using Mono.Cecil;
+using MonoMod.InlineRT;
+
+// ReSharper disable once CheckNamespace
+namespace MonoMod;
+
+internal static class MonoModRules
+{
+    static MonoModRules()
+    {
+        MonoModder? modder = null;
+        try
+        {
+            modder = MonoModRulesManager.Modder;
+            if (modder.Module.GetType("Avalonia.Win32.WindowImpl") is not { } windowImpl)
+            {
+                modder.Log("[Everywhere] Avalonia.Win32.WindowImpl was not found; corner-radius bridge was not injected.");
+                return;
+            }
+
+            var dependencyCache = modder
+                .GetType()
+                .GetField("DependencyCache", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                ?.GetValue(modder) as IDictionary;
+            ModuleDefinition? contractsModule = null;
+            if (dependencyCache is not null)
+            {
+                foreach (DictionaryEntry entry in dependencyCache)
+                {
+                    if (entry.Value is ModuleDefinition { Assembly.Name.Name: "Everywhere.Patches.Contracts" } module)
+                    {
+                        contractsModule = module;
+                        break;
+                    }
+                }
+            }
+
+            if (contractsModule?.Assembly?.Name is not { } contractsAssemblyName)
+            {
+                modder.Log("[Everywhere] Everywhere.Patches.Contracts could not be resolved; corner-radius bridge was not injected.");
+                return;
+            }
+
+            AssemblyNameReference? contractsReference = null;
+            foreach (var assemblyReference in modder.Module.AssemblyReferences)
+            {
+                if (assemblyReference.Name == contractsAssemblyName.Name)
+                {
+                    contractsReference = assemblyReference;
+                    break;
+                }
+            }
+
+            contractsReference ??= new AssemblyNameReference(contractsAssemblyName.Name, contractsAssemblyName.Version);
+            if (!modder.Module.AssemblyReferences.Contains(contractsReference))
+            {
+                modder.Module.AssemblyReferences.Add(contractsReference);
+            }
+
+            var feature = new TypeReference(
+                "Everywhere.Patches.Contracts.Interop",
+                "IWindowCornerRadiusFeature",
+                modder.Module,
+                contractsReference);
+
+#pragma warning disable CS8602
+            var interfaces = windowImpl.Interfaces ??
+                throw new InvalidOperationException("Avalonia.Win32.WindowImpl does not expose an interface collection.");
+#pragma warning restore CS8602
+            foreach (var implementation in interfaces)
+            {
+                if (implementation.InterfaceType.FullName == feature.FullName)
+                {
+                    return;
+                }
+            }
+
+            interfaces.Add(new InterfaceImplementation(feature));
+            modder.Log("[Everywhere] Injected IWindowCornerRadiusFeature into Avalonia.Win32.WindowImpl.");
+        }
+        catch (Exception exception)
+        {
+            modder?.Log($"[Everywhere] Corner-radius bridge injection failed: {exception}");
+            throw;
+        }
+    }
+}

--- a/patches/Everywhere.Patches.Avalonia.Win32/WinUiCompositionStubs.cs
+++ b/patches/Everywhere.Patches.Avalonia.Win32/WinUiCompositionStubs.cs
@@ -1,0 +1,185 @@
+using System.Numerics;
+using Avalonia.OpenGL.Egl;
+using Everywhere.Patches.Contracts.Interop;
+using MonoMod;
+
+// Avalonia's WinRT bindings are internal by design. These declarations provide the
+// compile-time shape required by the patch; MonoMod relinks them to the matching
+// internal types in Avalonia.Win32 when weaving the assembly.
+namespace Avalonia.Win32.WinRT
+{
+    [MonoModIgnore]
+    internal interface ICompositor;
+
+    [MonoModIgnore]
+    internal interface IVisual;
+
+    [MonoModIgnore]
+    internal interface ICompositionRoundedRectangleGeometry : IDisposable
+    {
+        void SetCornerRadius(Vector2 value);
+
+        void SetOffset(Vector2 value);
+
+        void SetSize(Vector2 value);
+    }
+}
+
+namespace Avalonia.Win32.WinRT.Composition
+{
+    [MonoModIgnore]
+    // ReSharper disable once ClassNeverInstantiated.Global
+    internal class WinUiCompositionShared
+    {
+        // This initializer only satisfies nullable analysis while compiling the patch donor.
+        // MonoMod relinks the property access to Avalonia.Win32's live compositor instance.
+        public ICompositor Compositor { get; } = null!;
+
+        // This is likewise a compile-time shape declaration. After weaving, it resolves to
+        // Avalonia.Win32's shared synchronization object rather than this null initializer.
+        public object SyncRoot { get; } = null!;
+    }
+
+    [MonoModPatch("Avalonia.Win32.WinRT.Composition.WinUiCompositedWindow")]
+    internal class patch_WinUiCompositedWindow : IDisposable
+    {
+        private const float BackdropClipInset = 2;
+
+        [MonoModIgnore]
+        private readonly WinUiCompositionShared _shared = null!;
+
+        [MonoModIgnore]
+        private readonly IVisual? _micaLight = null;
+
+        [MonoModIgnore]
+        private readonly IVisual? _micaDark = null;
+
+        [MonoModIgnore]
+        private readonly IVisual _blur = null!;
+
+        [MonoModIgnore]
+        private readonly IVisual _visual = null!;
+
+        [MonoModIgnore]
+        public extern EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo WindowInfo { get; }
+
+        private ICompositionRoundedRectangleGeometry? _everywhereCornerGeometry;
+        private ICompositionRoundedRectangleGeometry? _everywhereBackdropCornerGeometry;
+        private PixelSize _everywhereCornerSize;
+        private double _everywhereCornerScaling;
+        private float _everywhereCornerRadius = float.NaN;
+
+        [MonoModLinkTo("Avalonia.Win32.WinRT.Composition.WinUiCompositionUtils", "ClipVisual")]
+        private static extern ICompositionRoundedRectangleGeometry? ClipVisual(
+            ICompositor compositor,
+            float? cornerRadius,
+            params IVisual?[] visuals);
+
+        private static bool TryGetCornerRadius(
+            EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo windowInfo,
+            out double radius)
+        {
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            // Avalonia's Win32 platform implementation is extended at runtime to implement IWindowCornerRadiusFeature.
+            if (windowInfo is IWindowCornerRadiusFeature feature)
+                return feature.TryGetEffectiveCornerRadius(out radius);
+
+            radius = 0;
+            return false;
+        }
+
+        // The wrapper below must not use MonoModReplace: MonoMod needs to preserve
+        // Avalonia's implementation under this orig_ name before applying the wrapper.
+        public extern void orig_ResizeIfNeeded(PixelSize size);
+
+        public void ResizeIfNeeded(PixelSize size)
+        {
+            orig_ResizeIfNeeded(size);
+
+            lock (_shared.SyncRoot)
+            {
+                UpdateEverywhereCornerClip(size);
+            }
+        }
+
+        private void UpdateEverywhereCornerClip(PixelSize size)
+        {
+            if (!TryGetCornerRadius(WindowInfo, out var logicalRadius))
+                return;
+
+            var scaling = WindowInfo.Scaling;
+            var radius = (float)(logicalRadius * scaling);
+            var needsCreation = _everywhereCornerGeometry is null;
+            var sizeChanged = _everywhereCornerSize != size;
+            var scaleChanged = Math.Abs(_everywhereCornerScaling - scaling) > double.Epsilon;
+            var radiusChanged = float.IsNaN(_everywhereCornerRadius) || Math.Abs(_everywhereCornerRadius - radius) > float.Epsilon;
+
+            if (needsCreation)
+            {
+                // Keep the rendered content on the requested outer boundary. The backdrop uses
+                // a separate, slightly inset clip so its bright edge sampling cannot appear as
+                // a second border outside the Avalonia-rendered border.
+                _everywhereCornerGeometry = ClipVisual(
+                    _shared.Compositor,
+                    radius,
+                    _visual);
+                _everywhereBackdropCornerGeometry = ClipVisual(
+                    _shared.Compositor,
+                    Math.Max(0, radius - BackdropClipInset),
+                    _blur,
+                    _micaLight,
+                    _micaDark);
+            }
+            var geometry = _everywhereCornerGeometry;
+            if (geometry is null)
+                return;
+
+            if (!needsCreation && radiusChanged)
+                geometry.SetCornerRadius(new Vector2(radius, radius));
+
+            if (needsCreation || sizeChanged || scaleChanged)
+                geometry.SetSize(new Vector2(size.Width, size.Height));
+
+            var backdropGeometry = _everywhereBackdropCornerGeometry;
+            if (backdropGeometry is not null)
+            {
+                // Maximized and snapped windows suppress their radius. Do not leave a one-pixel
+                // backdrop gap along their square edges in that state.
+                var backdropInset = radius > 0 ? BackdropClipInset : 0;
+                if (needsCreation || radiusChanged)
+                {
+                    backdropGeometry.SetCornerRadius(new Vector2(
+                        Math.Max(0, radius - backdropInset),
+                        Math.Max(0, radius - backdropInset)));
+                    backdropGeometry.SetOffset(new Vector2(backdropInset, backdropInset));
+                }
+
+                if (needsCreation || sizeChanged || scaleChanged || radiusChanged)
+                {
+                    backdropGeometry.SetSize(new Vector2(
+                        Math.Max(0, size.Width - backdropInset * 2),
+                        Math.Max(0, size.Height - backdropInset * 2)));
+                }
+            }
+
+            _everywhereCornerSize = size;
+            _everywhereCornerScaling = scaling;
+            _everywhereCornerRadius = radius;
+        }
+
+        // Keep Avalonia's original disposal path so all of its COM objects are released.
+        public extern void orig_Dispose();
+
+        public void Dispose()
+        {
+            lock (_shared.SyncRoot)
+            {
+                _everywhereCornerGeometry?.Dispose();
+                _everywhereCornerGeometry = null;
+                _everywhereBackdropCornerGeometry?.Dispose();
+                _everywhereBackdropCornerGeometry = null;
+                orig_Dispose();
+            }
+        }
+    }
+}

--- a/patches/Everywhere.Patches.Avalonia.Win32/patch_WindowImpl.cs
+++ b/patches/Everywhere.Patches.Avalonia.Win32/patch_WindowImpl.cs
@@ -1,0 +1,67 @@
+using Everywhere.Patches.Contracts.Interop;
+using MonoMod;
+
+namespace Everywhere.Patches.Avalonia.Win32;
+
+[MonoModPatch("Avalonia.Win32.WindowImpl")]
+internal class patch_WindowImpl : IWindowCornerRadiusFeature
+{
+    private long _everywhereCornerRadiusBits;
+    private int _everywhereCornerRadiusConfigured;
+    private int _everywhereCornerRadiusSuppressed;
+    private int _everywhereNativeFrameRenderingSuppressed;
+
+    public void SetCornerRadius(double radius)
+    {
+        if (!double.IsFinite(radius) || radius < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), radius, "The corner radius must be finite and non-negative.");
+        }
+
+        radius = Math.Min(radius, 4096);
+        Volatile.Write(ref _everywhereCornerRadiusBits, BitConverter.DoubleToInt64Bits(radius));
+        Volatile.Write(ref _everywhereCornerRadiusConfigured, 1);
+    }
+
+    public void SetNativeFrameRenderingSuppressed(bool suppressed) =>
+        Volatile.Write(ref _everywhereNativeFrameRenderingSuppressed, suppressed ? 1 : 0);
+
+    public void SetCornerRadiusSuppressed(bool suppressed) =>
+        Volatile.Write(ref _everywhereCornerRadiusSuppressed, suppressed ? 1 : 0);
+
+    public bool TryGetEffectiveCornerRadius(out double radius)
+    {
+        if (Volatile.Read(ref _everywhereCornerRadiusConfigured) == 0)
+        {
+            radius = 0;
+            return false;
+        }
+
+        if (Volatile.Read(ref _everywhereCornerRadiusSuppressed) != 0)
+        {
+            radius = 0;
+            return true;
+        }
+
+        var bits = Volatile.Read(ref _everywhereCornerRadiusBits);
+        radius = BitConverter.Int64BitsToDouble(bits);
+        return true;
+    }
+
+    // Avalonia reapplies its preferred policy whenever it extends the client area or changes the
+    // window state. Preserve that behavior for ordinary windows, but keep native rendering disabled
+    // after Everywhere has successfully installed the complete custom frame for ChatWindow.
+    private extern void orig_SetNCRenderingPolicy(
+        global::Avalonia.Win32.Interop.UnmanagedMethods.DwmNCRenderingPolicy value);
+
+    private void SetNCRenderingPolicy(
+        global::Avalonia.Win32.Interop.UnmanagedMethods.DwmNCRenderingPolicy value)
+    {
+        if (Volatile.Read(ref _everywhereNativeFrameRenderingSuppressed) != 0)
+        {
+            value = global::Avalonia.Win32.Interop.UnmanagedMethods.DwmNCRenderingPolicy.DWMNCRP_DISABLED;
+        }
+
+        orig_SetNCRenderingPolicy(value);
+    }
+}

--- a/patches/Everywhere.Patches.AvaloniaEdit/patch_TextAreaTextInputMethodClient.cs
+++ b/patches/Everywhere.Patches.AvaloniaEdit/patch_TextAreaTextInputMethodClient.cs
@@ -6,7 +6,7 @@
 using Avalonia;
 using Avalonia.Input.TextInput;
 using AvaloniaEdit.Editing;
-using Everywhere.Views;
+using Everywhere.Patches.Contracts.Views;
 using MonoMod;
 
 namespace Everywhere.Patches.AvaloniaEdit;

--- a/patches/Everywhere.Patches.Contracts/Everywhere.Patches.Contracts.csproj
+++ b/patches/Everywhere.Patches.Contracts/Everywhere.Patches.Contracts.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Everywhere.Patches.Contracts</AssemblyName>
+    <RootNamespace>Everywhere.Patches.Contracts</RootNamespace>
+    <NoWarn>$(NoWarn),CA1050</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" />
+  </ItemGroup>
+
+</Project>

--- a/patches/Everywhere.Patches.Contracts/Interop/IWindowCornerRadiusFeature.cs
+++ b/patches/Everywhere.Patches.Contracts/Interop/IWindowCornerRadiusFeature.cs
@@ -1,0 +1,33 @@
+namespace Everywhere.Patches.Contracts.Interop;
+
+/// <summary>
+/// Runtime contract injected into Avalonia's Windows platform implementation by MonoMod.
+/// </summary>
+public interface IWindowCornerRadiusFeature
+{
+    /// <summary>
+    /// Sets the requested corner radius in Avalonia logical pixels.
+    /// </summary>
+    /// <param name="radius">The requested radius. Values are clamped by the platform implementation.</param>
+    void SetCornerRadius(double radius);
+
+    /// <summary>
+    /// Keeps Avalonia from restoring DWM non-client rendering after the application has replaced
+    /// the native frame with its own compositor clip and shadow.
+    /// </summary>
+    /// <param name="suppressed">Whether Avalonia should keep native frame rendering disabled.</param>
+    void SetNativeFrameRenderingSuppressed(bool suppressed);
+
+    /// <summary>
+    /// Temporarily replaces the requested radius with zero for native window states that require square corners.
+    /// </summary>
+    /// <param name="suppressed">Whether the effective radius should be zero.</param>
+    void SetCornerRadiusSuppressed(bool suppressed);
+
+    /// <summary>
+    /// Gets the effective radius for the current native window state.
+    /// </summary>
+    /// <param name="radius">The effective radius in Avalonia logical pixels.</param>
+    /// <returns><see langword="true" /> when a radius has been configured for the window.</returns>
+    bool TryGetEffectiveCornerRadius(out double radius);
+}

--- a/patches/Everywhere.Patches.Contracts/Views/ChatInputAreaEvents.cs
+++ b/patches/Everywhere.Patches.Contracts/Views/ChatInputAreaEvents.cs
@@ -2,7 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 
-namespace Everywhere.Views;
+namespace Everywhere.Patches.Contracts.Views;
 
 public sealed class PreeditChangedEventArgs(RoutedEvent routedEvent, string? preeditText, Rect cursorRectangle) : RoutedEventArgs(routedEvent)
 {

--- a/src/Build.Patches.targets
+++ b/src/Build.Patches.targets
@@ -32,6 +32,13 @@
                       Condition="'$(IsMacOS)' == 'true'"
                       GlobalPropertiesToRemove="RuntimeIdentifier" />
 
+    <ProjectReference Include="$(PatchesBasePath)Everywhere.Patches.Avalonia.Win32\Everywhere.Patches.Avalonia.Win32.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="PatchAssembly"
+                      PatchTargets="Avalonia.Win32"
+                      Condition="'$(IsWindows)' == 'true'"
+                      GlobalPropertiesToRemove="RuntimeIdentifier" />
+
     <ProjectReference Include="$(PatchesBasePath)Everywhere.Patches.AvaloniaEdit\Everywhere.Patches.AvaloniaEdit.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="PatchAssembly"

--- a/src/Everywhere.Core/Everywhere.Core.csproj
+++ b/src/Everywhere.Core/Everywhere.Core.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Avalonia.AvaloniaEdit"/>
     <PackageReference Include="Avalonia.HtmlRenderer"/>
     <PackageReference Include="AvaloniaEdit.TextMate"/>
-    <PackageReference Include="ClassicDiagnostics.Avalonia"/>
     <PackageReference Include="DiffPlex"/>
     <PackageReference Include="FuzzySharp"/>
     <PackageReference Include="GnomeStack.Os.Secrets"/>
@@ -69,12 +68,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Condition="'$(Configuration)' == 'Debug'" Include="..\..\..\ClassicDiagnostics.Avalonia\src\ClassicDiagnostics.Avalonia.csproj"/>
+    <ProjectReference Include="..\..\3rd\ClassicDiagnostics.Avalonia\src\ClassicDiagnostics.Avalonia.csproj"/>
     <ProjectReference Include="..\..\3rd\MessagePack-CSharp\src\MessagePack.SourceGenerator\MessagePack.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>
     <ProjectReference Include="..\..\3rd\semantic-kernel-patch\Connectors.Google\Connectors.Google.csproj"/>
     <ProjectReference Include="..\..\3rd\Motion.Avalonia\src\Motion.Avalonia\Motion.Avalonia.csproj"/>
     <ProjectReference Include="..\..\3rd\shad-ui\src\ShadUI\ShadUI.csproj"/>
     <ProjectReference Include="..\Everywhere.Abstractions\Everywhere.Abstractions.csproj"/>
+    <ProjectReference Include="..\..\patches\Everywhere.Patches.Contracts\Everywhere.Patches.Contracts.csproj"/>
     <ProjectReference Include="..\Everywhere.Configuration.SourceGenerator\Everywhere.Configuration.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>
     <ProjectReference Include="..\Everywhere.I18N.Abstractions\Everywhere.I18N.Abstractions.csproj"/>
     <ProjectReference Include="..\Everywhere.I18N.SourceGenerator\Everywhere.I18N.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>

--- a/src/Everywhere.Core/Interop/IWindowHelper.cs
+++ b/src/Everywhere.Core/Interop/IWindowHelper.cs
@@ -49,6 +49,13 @@ public interface IWindowHelper
     void RequestUserAttention(Window window);
 
     /// <summary>
+    /// Sets the requested native window corner radius in Avalonia logical pixels.
+    /// </summary>
+    /// <param name="window">The target window.</param>
+    /// <param name="radius">The requested radius.</param>
+    void SetCornerRadius(Window window, double radius);
+
+    /// <summary>
     /// Initialize the window properties by its type
     /// </summary>
     /// <param name="window"></param>

--- a/src/Everywhere.Core/Views/Chat/ChatTextEditor.axaml.cs
+++ b/src/Everywhere.Core/Views/Chat/ChatTextEditor.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
 using AvaloniaEdit;
 using AvaloniaEdit.Rendering;
+using Everywhere.Patches.Contracts.Views;
 using Everywhere.Utilities;
 using LiveMarkdown.Avalonia;
 using Serilog;

--- a/src/Everywhere.Core/Views/Chat/ChatWindow.axaml
+++ b/src/Everywhere.Core/Views/Chat/ChatWindow.axaml
@@ -12,8 +12,9 @@
   x:DataType="vm:ChatWindowViewModel" x:TypeArguments="vm:ChatWindowViewModel"
   Background="{DynamicResource AcrylicWindowBackgroundColor}"
   BorderBrush="{DynamicResource BorderColor}"
-  SizeToContent="WidthAndHeight" TransparencyLevelHint="AcrylicBlur,Blur,None"
-  WindowDecorations="BorderOnly" WindowStartupLocation="CenterScreen">
+  CornerRadius="20" SizeToContent="WidthAndHeight"
+  TransparencyLevelHint="AcrylicBlur,Blur,None" WindowDecorations="BorderOnly"
+  WindowStartupLocation="CenterScreen">
 
   <v:ReactiveShadWindow.BorderThickness>
     <OnPlatform
@@ -64,11 +65,11 @@
               <Setter Property="MinWidth" Value="28"/>
               <Setter Property="Width" Value="28"/>
               <Setter Property="Padding" Value="0"/>
-              <Setter Property="CornerRadius" Value="4"/>
+              <Setter Property="CornerRadius" Value="14"/>
               <Setter Property="Background" Value="{DynamicResource TransparentColor}"/>
 
-              <Style Selector="^.Close /template/ Border#HoverBackground">
-                <Setter Property="Background" Value="#C42B1C"/>
+              <Style Selector="^.Close">
+                <Setter Property="shadui:ButtonAssist.HoverBackground" Value="#99C42B1C"/>
               </Style>
 
               <Style Selector="^ LucideIcon">
@@ -749,7 +750,7 @@
         </Button>
 
         <StackPanel
-          Grid.Row="1" Margin="12"
+          Grid.Row="1" Margin="10"
           Orientation="Vertical" Spacing="8">
           <DockPanel>
             <DockPanel.IsVisible>

--- a/src/Everywhere.Core/Views/Chat/ChatWindow.axaml.cs
+++ b/src/Everywhere.Core/Views/Chat/ChatWindow.axaml.cs
@@ -106,6 +106,7 @@ public partial class ChatWindow :
         ApplyTemplate();
 
         _windowHelper.InitializeWindow(this);
+        _windowHelper.SetCornerRadius(this, CornerRadius.TopLeft);
         _windowHelper.SetCloaked(this, true);
 
         // Setup window placement saving after initialization

--- a/src/Everywhere.Linux/Interop/X11WindowBackend.cs
+++ b/src/Everywhere.Linux/Interop/X11WindowBackend.cs
@@ -178,6 +178,11 @@ public sealed class X11WindowBackend : IWindowBackend, IEventHelper
             WindowManager.RequestUserAttention((X11Window)x11Handle);
     }
 
+    public void SetCornerRadius(AvaloniaWindow window, double radius)
+    {
+        // X11 window shaping is intentionally not used here because it does not provide antialiasing.
+    }
+
     public void InitializeWindow(AvaloniaWindow window)
     {
 

--- a/src/Everywhere.Mac/Interop/WindowHelper.cs
+++ b/src/Everywhere.Mac/Interop/WindowHelper.cs
@@ -1,8 +1,13 @@
-﻿using Avalonia;
+﻿using System.Reactive.Disposables;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Interactivity;
+using CoreAnimation;
 using Everywhere.Interop;
+using Everywhere.Utilities;
 using Everywhere.Views;
 using ObjCRuntime;
 
@@ -59,6 +64,8 @@ public sealed class WindowHelper : IWindowHelper
     private void HandleWindowOpened(Window window, RoutedEventArgs args)
     {
         if (window is not ChatWindow) OpenedWindowCount++;
+
+        ApplyNativeBackdrop(window);
     }
 
     private void HandleWindowClosed(Window window, RoutedEventArgs args)
@@ -198,9 +205,19 @@ public sealed class WindowHelper : IWindowHelper
         NSApplication.SharedApplication.RequestUserAttention(NSRequestUserAttentionType.InformationalRequest);
     }
 
+    public void SetCornerRadius(Window window, double radius)
+    {
+        if (window is ChatWindow chatWindow)
+        {
+            ChatWindowFrame.Create(chatWindow, radius);
+        }
+    }
+
     public void InitializeWindow(Window window)
     {
         if (GetNativeWindow(window) is not { } nativeWindow) return;
+
+        ApplyNativeBackdrop(window, nativeWindow);
 
         if (window is ChatWindow)
         {
@@ -221,5 +238,159 @@ public sealed class WindowHelper : IWindowHelper
     private static NSWindow? GetNativeWindow(Window window)
     {
         return window.TryGetPlatformHandle()?.Handle is { } handle ? Runtime.GetNSObject<NSWindow>(handle) : null;
+    }
+
+    private static void ApplyNativeBackdrop(Window window)
+    {
+        if (GetNativeWindow(window) is { } nativeWindow)
+        {
+            ApplyNativeBackdrop(window, nativeWindow);
+        }
+    }
+
+    private static void ApplyNativeBackdrop(Window window, NSWindow nativeWindow)
+    {
+        if (window.ActualTransparencyLevel != WindowTransparencyLevel.AcrylicBlur) return;
+
+        nativeWindow.IsOpaque = false;
+        nativeWindow.BackgroundColor = NSColor.Clear;
+
+        if (nativeWindow.ContentView is not { } contentView || FindBackdropView(contentView) is not { } backdropView)
+            return;
+
+        // Avalonia.Native uses the deprecated Light material for AcrylicBlur, which ignores the
+        // window's DarkAqua appearance. A semantic material inherits the effective appearance while
+        // retaining AppKit's normal active/inactive states.
+        backdropView.Material = NSVisualEffectMaterial.UnderWindowBackground;
+        backdropView.State = NSVisualEffectState.FollowsWindowActiveState;
+    }
+
+    private static NSVisualEffectView? FindBackdropView(NSView view)
+    {
+        if (view is NSVisualEffectView { BlendingMode: NSVisualEffectBlendingMode.BehindWindow } backdropView)
+        {
+            return backdropView;
+        }
+
+        foreach (var subview in view.Subviews)
+        {
+            if (FindBackdropView(subview) is { } descendant)
+            {
+                return descendant;
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class ChatWindowFrame : IDisposable
+    {
+        private readonly ChatWindow _window;
+        private readonly NSWindow _nativeWindow;
+        private readonly double _radius;
+        private readonly CompositeDisposable _subscriptions = new(5);
+
+        private bool _isFullScreen;
+        private bool? _frameSuppressed;
+        private IDisposable? _cornerRadiusOverride;
+        private IDisposable? _borderThicknessOverride;
+
+        private ChatWindowFrame(ChatWindow window, NSWindow nativeWindow, double radius)
+        {
+            _window = window;
+            _nativeWindow = nativeWindow;
+            _radius = Math.Max(0, radius);
+        }
+
+        public static void Create(ChatWindow window, double radius)
+        {
+            if (GetNativeWindow(window) is not { } nativeWindow) return;
+
+            // ChatWindow is an application-lifetime singleton. Its Avalonia and AppKit
+            // subscriptions keep this controller alive, so WindowHelper needs no cache.
+            var frame = new ChatWindowFrame(window, nativeWindow, radius);
+            frame.Attach();
+        }
+
+        private void Attach()
+        {
+            _subscriptions.Add(_window.GetObservable(Window.WindowStateProperty).Subscribe(_ => Update()));
+            _subscriptions.Add(_window.GetObservable(Visual.IsVisibleProperty).Subscribe(_ => Update()));
+            _subscriptions.Add(NSWindow.Notifications.ObserveDidResize(_nativeWindow, (_, _) => Update()));
+            _subscriptions.Add(NSWindow.Notifications.ObserveWillEnterFullScreen(_nativeWindow, (_, _) =>
+            {
+                _isFullScreen = true;
+                Update();
+            }));
+            _subscriptions.Add(NSWindow.Notifications.ObserveDidExitFullScreen(_nativeWindow, (_, _) =>
+            {
+                _isFullScreen = false;
+                Update();
+            }));
+
+            Update();
+        }
+
+        private void Update()
+        {
+            ApplyNativeBackdrop(_window, _nativeWindow);
+
+            var suppressFrame =
+                !_window.IsVisible ||
+                _nativeWindow.IsMiniaturized ||
+                _nativeWindow.IsZoomed ||
+                _isFullScreen ||
+                (_nativeWindow.StyleMask & NSWindowStyle.FullScreenWindow) != 0 ||
+                _window.WindowState is WindowState.Minimized or WindowState.Maximized or WindowState.FullScreen;
+
+            if (_frameSuppressed != suppressFrame)
+            {
+                _frameSuppressed = suppressFrame;
+                if (suppressFrame)
+                {
+                    // Animation priority creates temporary value frames above the AXAML local
+                    // values. Disposing them restores whichever frame values are underneath.
+                    _cornerRadiusOverride = _window.SetValue(TemplatedControl.CornerRadiusProperty, default, BindingPriority.Animation);
+                    _borderThicknessOverride = _window.SetValue(TemplatedControl.BorderThicknessProperty, default, BindingPriority.Animation);
+                }
+                else
+                {
+                    DisposeHelper.DisposeToDefault(ref _cornerRadiusOverride);
+                    DisposeHelper.DisposeToDefault(ref _borderThicknessOverride);
+                }
+
+                _window.InvalidateVisual();
+            }
+
+            var effectiveRadius = suppressFrame ? 0 : _radius;
+            if (_nativeWindow.ContentView is { } contentView)
+            {
+                // Full-screen transitions can rebuild AppKit's frame view hierarchy, so resolve
+                // the content layer on every native state update instead of caching it.
+                if (contentView.Layer is { } layer)
+                {
+                    CATransaction.Begin();
+                    try
+                    {
+                        CATransaction.DisableActions = true;
+                        layer.CornerRadius = (nfloat)effectiveRadius;
+                        layer.CornerCurve = CACornerCurve.Continuous;
+                        layer.MasksToBounds = effectiveRadius > 0;
+                    }
+                    finally
+                    {
+                        CATransaction.Commit();
+                    }
+                }
+            }
+
+            _nativeWindow.HasShadow = !suppressFrame;
+            _nativeWindow.InvalidateShadow();
+        }
+
+        public void Dispose()
+        {
+            _subscriptions.Dispose();
+        }
     }
 }

--- a/src/Everywhere.Mac/Interop/WindowHelper.cs
+++ b/src/Everywhere.Mac/Interop/WindowHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reactive.Disposables;
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -285,11 +286,14 @@ public sealed class WindowHelper : IWindowHelper
 
     private sealed class ChatWindowFrame : IDisposable
     {
+        private static readonly ConditionalWeakTable<ChatWindow, ChatWindowFrame> Frames = new();
+
         private readonly ChatWindow _window;
         private readonly NSWindow _nativeWindow;
-        private readonly double _radius;
-        private readonly CompositeDisposable _subscriptions = new(5);
+        private readonly CompositeDisposable _subscriptions = new(6);
 
+        private double _radius;
+        private bool _isDisposed;
         private bool _isFullScreen;
         private bool? _frameSuppressed;
         private IDisposable? _cornerRadiusOverride;
@@ -306,10 +310,20 @@ public sealed class WindowHelper : IWindowHelper
         {
             if (GetNativeWindow(window) is not { } nativeWindow) return;
 
-            // ChatWindow is an application-lifetime singleton. Its Avalonia and AppKit
-            // subscriptions keep this controller alive, so WindowHelper needs no cache.
+            if (Frames.TryGetValue(window, out var existingFrame))
+            {
+                if (existingFrame._nativeWindow.Handle == nativeWindow.Handle)
+                {
+                    existingFrame.SetRadius(radius);
+                    return;
+                }
+
+                existingFrame.Dispose();
+            }
+
             var frame = new ChatWindowFrame(window, nativeWindow, radius);
             frame.Attach();
+            Frames.Add(window, frame);
         }
 
         private void Attach()
@@ -317,6 +331,7 @@ public sealed class WindowHelper : IWindowHelper
             _subscriptions.Add(_window.GetObservable(Window.WindowStateProperty).Subscribe(_ => Update()));
             _subscriptions.Add(_window.GetObservable(Visual.IsVisibleProperty).Subscribe(_ => Update()));
             _subscriptions.Add(NSWindow.Notifications.ObserveDidResize(_nativeWindow, (_, _) => Update()));
+            _subscriptions.Add(NSWindow.Notifications.ObserveWillClose(_nativeWindow, (_, _) => Dispose()));
             _subscriptions.Add(NSWindow.Notifications.ObserveWillEnterFullScreen(_nativeWindow, (_, _) =>
             {
                 _isFullScreen = true;
@@ -328,6 +343,12 @@ public sealed class WindowHelper : IWindowHelper
                 Update();
             }));
 
+            Update();
+        }
+
+        private void SetRadius(double radius)
+        {
+            _radius = Math.Max(0, radius);
             Update();
         }
 
@@ -390,6 +411,16 @@ public sealed class WindowHelper : IWindowHelper
 
         public void Dispose()
         {
+            if (_isDisposed) return;
+            _isDisposed = true;
+
+            if (Frames.TryGetValue(_window, out var currentFrame) && ReferenceEquals(currentFrame, this))
+            {
+                Frames.Remove(_window);
+            }
+
+            DisposeHelper.DisposeToDefault(ref _cornerRadiusOverride);
+            DisposeHelper.DisposeToDefault(ref _borderThicknessOverride);
             _subscriptions.Dispose();
         }
     }

--- a/src/Everywhere.Windows/Everywhere.Windows.csproj
+++ b/src/Everywhere.Windows/Everywhere.Windows.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\3rd\OfficeCLI\src\officecli\officecli.csproj"/>
     <ProjectReference Include="..\Everywhere.Cloud\Everywhere.Cloud.csproj"/>
     <ProjectReference Include="..\Everywhere.Core\Everywhere.Core.csproj"/>
+    <ProjectReference Include="..\..\patches\Everywhere.Patches.Contracts\Everywhere.Patches.Contracts.csproj"/>
     <ProjectReference Include="..\Everywhere.I18N.Abstractions\Everywhere.I18N.Abstractions.csproj"/>
     <ProjectReference Include="..\Everywhere.I18N.SourceGenerator\Everywhere.I18N.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>
   </ItemGroup>
@@ -71,6 +72,7 @@
     <TrimmerRootAssembly Include="Everywhere.Abstractions"/>
     <TrimmerRootAssembly Include="Everywhere.Core"/>
     <TrimmerRootAssembly Include="Everywhere.Cloud"/>
+    <TrimmerRootAssembly Include="Everywhere.Patches.Contracts"/>
     <TrimmerRootAssembly Include="Everywhere.I18N.Abstractions"/>
     <TrimmerRootAssembly Include="Anthropic"/>
     <TrimmerRootAssembly Include="CSharpMath.Avalonia"/>

--- a/src/Everywhere.Windows/Interop/ChatWindowShadow.cs
+++ b/src/Everywhere.Windows/Interop/ChatWindowShadow.cs
@@ -1,0 +1,454 @@
+﻿using System.Drawing;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Dwm;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.WindowsAndMessaging;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Everywhere.Patches.Contracts.Interop;
+using Everywhere.Utilities;
+using Everywhere.Views;
+using SkiaSharp;
+
+namespace Everywhere.Windows.Interop;
+
+internal sealed class ChatWindowShadow
+{
+    private const uint DwmColorNone = 0xFFFFFFFE;
+    private const float ShadowPadding = 12;
+    private const float ShadowBlurRadius = 12;
+    private const byte ActiveShadowAlpha = 100;
+    private const byte InactiveShadowAlpha = 60;
+
+    private readonly ChatWindow _window;
+    private readonly HWND _owner;
+    private readonly IWindowCornerRadiusFeature _cornerRadiusFeature;
+
+    private HWND _shadow;
+    private bool? _windowFrameSuppressed;
+    private IDisposable? _cornerRadiusOverride;
+    private IDisposable? _borderThicknessOverride;
+    private bool _shadowVisible;
+    private int _shadowFrameWidth;
+    private int _shadowFrameHeight;
+    private double _shadowScaling;
+    private float _shadowRadius = float.NaN;
+    private byte _shadowAlpha;
+    private bool _isActive;
+
+    private ChatWindowShadow(ChatWindow window, HWND owner, IWindowCornerRadiusFeature cornerRadiusFeature)
+    {
+        _window = window;
+        _owner = owner;
+        _cornerRadiusFeature = cornerRadiusFeature;
+        _isActive = PInvoke.GetForegroundWindow() == owner;
+    }
+
+    public static void Attach(ChatWindow window)
+    {
+        // ReSharper disable once SuspiciousTypeConversion.Global
+        if (window.PlatformImpl is not IWindowCornerRadiusFeature cornerRadiusFeature)
+        {
+            return;
+        }
+
+        // Fail closed until the shadow HWND and DWM policy have both been established. A later
+        // SetCornerRadius call can still store the requested radius without exposing a clipped
+        // content-only window.
+        cornerRadiusFeature.SetCornerRadiusSuppressed(true);
+        if (window.TryGetPlatformHandle() is not { } handle)
+        {
+            return;
+        }
+
+        new ChatWindowShadow(window, (HWND)handle.Handle, cornerRadiusFeature).Attach();
+    }
+
+    private unsafe void Attach()
+    {
+        using var hInstance = PInvoke.GetModuleHandle();
+        _shadow = PInvoke.CreateWindowEx(
+            WINDOW_EX_STYLE.WS_EX_LAYERED |
+            WINDOW_EX_STYLE.WS_EX_TOOLWINDOW |
+            WINDOW_EX_STYLE.WS_EX_NOACTIVATE |
+            WINDOW_EX_STYLE.WS_EX_TRANSPARENT,
+            "STATIC",
+            "Everywhere.ChatWindowShadow",
+            WINDOW_STYLE.WS_POPUP | WINDOW_STYLE.WS_DISABLED,
+            0,
+            0,
+            1,
+            1,
+            hWndParent: _owner,
+            hInstance: hInstance);
+
+        if (_shadow.IsNull)
+        {
+            return;
+        }
+
+        fixed (char* propertyName = "UIA_WindowVisibilityOverridden")
+        {
+            // Keep the auxiliary HWND visible to desktop composition while hiding it from UIA-
+            // based window discovery, so capture tools can resolve the owner as the real window.
+            PInvoke.SetProp(_shadow, new PCWSTR(propertyName), new HANDLE(2));
+        }
+
+        if (!TryDisableNativeFrameRendering())
+        {
+            PInvoke.DestroyWindow(_shadow);
+            _shadow = HWND.Null;
+            return;
+        }
+
+        _cornerRadiusFeature.SetNativeFrameRenderingSuppressed(true);
+        Win32Properties.AddWindowStylesCallback(_window, WindowStylesCallback);
+        ApplyNativeBehaviorStyles();
+        Win32Properties.AddWndProcHookCallback(_window, WndProcHookCallback);
+        Update();
+    }
+
+    private unsafe bool TryDisableNativeFrameRendering()
+    {
+        const int dwmNcRenderingPolicyDisabled = 1;
+        var policy = dwmNcRenderingPolicyDisabled;
+        var result = PInvoke.DwmSetWindowAttribute(
+            _owner,
+            DWMWINDOWATTRIBUTE.DWMWA_NCRENDERING_POLICY,
+            &policy,
+            sizeof(int));
+        if (result.Failed)
+        {
+            return false;
+        }
+
+        var transitionsForcedDisabled = 0;
+        PInvoke.DwmSetWindowAttribute(
+            _owner,
+            DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED,
+            &transitionsForcedDisabled,
+            sizeof(int));
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+        {
+            var borderColor = DwmColorNone;
+            PInvoke.DwmSetWindowAttribute(
+                _owner,
+                DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR,
+                &borderColor,
+                sizeof(uint));
+        }
+
+        return true;
+    }
+
+    private void ApplyNativeBehaviorStyles()
+    {
+        var style = PInvoke.GetWindowLong(_owner, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
+        var updatedStyle = style | (int)(WINDOW_STYLE.WS_CAPTION | WINDOW_STYLE.WS_SYSMENU);
+        if (updatedStyle != style)
+        {
+            PInvoke.SetWindowLong(_owner, WINDOW_LONG_PTR_INDEX.GWL_STYLE, updatedStyle);
+        }
+
+        PInvoke.SetWindowPos(
+            _owner,
+            HWND.Null,
+            0,
+            0,
+            0,
+            0,
+            SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED |
+            SET_WINDOW_POS_FLAGS.SWP_NOMOVE |
+            SET_WINDOW_POS_FLAGS.SWP_NOSIZE |
+            SET_WINDOW_POS_FLAGS.SWP_NOZORDER |
+            SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+    }
+
+    private static (uint style, uint exStyle) WindowStylesCallback(uint style, uint exStyle) =>
+        (style | (uint)(WINDOW_STYLE.WS_CAPTION | WINDOW_STYLE.WS_SYSMENU), exStyle);
+
+    private IntPtr WndProcHookCallback(
+        IntPtr hWnd,
+        uint msg,
+        IntPtr wParam,
+        IntPtr lParam,
+        ref bool handled)
+    {
+        switch ((WINDOW_MESSAGE)msg)
+        {
+            case WINDOW_MESSAGE.WM_ACTIVATE:
+                _isActive = (wParam.ToInt64() & 0xffff) != 0;
+                Update();
+                break;
+            case WINDOW_MESSAGE.WM_WINDOWPOSCHANGED:
+                Update();
+                break;
+            case WINDOW_MESSAGE.WM_NCDESTROY:
+                Dispose();
+                break;
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private void Update()
+    {
+        var suppressWindowFrame =
+            !PInvoke.IsWindowVisible(_owner) ||
+            PInvoke.IsIconic(_owner) ||
+            PInvoke.IsZoomed(_owner) ||
+            PInvoke.IsWindowArranged(_owner) ||
+            _window.WindowState == WindowState.FullScreen;
+
+        if (_windowFrameSuppressed != suppressWindowFrame)
+        {
+            _windowFrameSuppressed = suppressWindowFrame;
+            _cornerRadiusFeature.SetCornerRadiusSuppressed(suppressWindowFrame);
+            if (suppressWindowFrame)
+            {
+                // Animation priority creates temporary value frames above the AXAML local
+                // values. Disposing them restores whichever frame values are underneath.
+                _cornerRadiusOverride = _window.SetValue(
+                    TemplatedControl.CornerRadiusProperty,
+                    default,
+                    BindingPriority.Animation);
+                _borderThicknessOverride = _window.SetValue(
+                    TemplatedControl.BorderThicknessProperty,
+                    default,
+                    BindingPriority.Animation);
+            }
+            else
+            {
+                DisposeHelper.DisposeToDefault(ref _cornerRadiusOverride);
+                DisposeHelper.DisposeToDefault(ref _borderThicknessOverride);
+            }
+
+            _window.InvalidateVisual();
+        }
+
+        if (suppressWindowFrame ||
+            !_cornerRadiusFeature.TryGetEffectiveCornerRadius(out var logicalRadius) ||
+            !TryGetClientBounds(out var frame))
+        {
+            Hide();
+            return;
+        }
+
+        var scaling = _window.RenderScaling;
+        var radius = (float)(logicalRadius * scaling);
+        radius = Math.Min(radius, Math.Min(frame.Width, frame.Height) / 2f);
+        var padding = (int)Math.Ceiling(ShadowPadding * scaling);
+        var width = frame.Width + padding * 2;
+        var height = frame.Height + padding * 2;
+        var shadowAlpha = _isActive ? ActiveShadowAlpha : InactiveShadowAlpha;
+        var redraw =
+            _shadowFrameWidth != frame.Width ||
+            _shadowFrameHeight != frame.Height ||
+            Math.Abs(_shadowScaling - scaling) > double.Epsilon ||
+            float.IsNaN(_shadowRadius) ||
+            Math.Abs(_shadowRadius - radius) > float.Epsilon ||
+            _shadowAlpha != shadowAlpha;
+
+        if (redraw)
+        {
+            if (!Render(
+                    frame.X - padding,
+                    frame.Y - padding,
+                    width,
+                    height,
+                    padding,
+                    radius,
+                    scaling,
+                    shadowAlpha))
+            {
+                Hide();
+                return;
+            }
+
+            _shadowFrameWidth = frame.Width;
+            _shadowFrameHeight = frame.Height;
+            _shadowScaling = scaling;
+            _shadowRadius = radius;
+            _shadowAlpha = shadowAlpha;
+        }
+        else
+        {
+            PInvoke.SetWindowPos(
+                _shadow,
+                HWND.Null,
+                frame.X - padding,
+                frame.Y - padding,
+                width,
+                height,
+                SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE | SET_WINDOW_POS_FLAGS.SWP_NOZORDER);
+        }
+
+        if (!_shadowVisible)
+        {
+            PInvoke.ShowWindow(_shadow, SHOW_WINDOW_CMD.SW_SHOWNOACTIVATE);
+            _shadowVisible = true;
+        }
+    }
+
+    private bool TryGetClientBounds(out RECT frame)
+    {
+        if (!PInvoke.GetClientRect(_owner, out var clientRect) || clientRect is not { Width: > 0, Height: > 0 })
+        {
+            frame = default;
+            return false;
+        }
+
+        var origin = new Point(clientRect.left, clientRect.top);
+        if (!PInvoke.ClientToScreen(_owner, ref origin))
+        {
+            frame = default;
+            return false;
+        }
+
+        frame = new RECT(origin.X, origin.Y, origin.X + clientRect.Width, origin.Y + clientRect.Height);
+        return true;
+    }
+
+    private unsafe bool Render(
+        int x,
+        int y,
+        int width,
+        int height,
+        int padding,
+        float radius,
+        double scaling,
+        byte shadowAlpha)
+    {
+        var screenDc = PInvoke.GetDC(HWND.Null);
+        if (screenDc.IsNull)
+        {
+            return false;
+        }
+
+        var memoryDc = PInvoke.CreateCompatibleDC(screenDc);
+        if (memoryDc.IsNull)
+        {
+            PInvoke.ReleaseDC(HWND.Null, screenDc);
+            return false;
+        }
+
+        HBITMAP bitmap = default;
+        HGDIOBJ previousBitmap = default;
+        try
+        {
+            var bitmapInfo = new BITMAPINFO
+            {
+                bmiHeader = new BITMAPINFOHEADER
+                {
+                    biSize = (uint)sizeof(BITMAPINFOHEADER),
+                    biWidth = width,
+                    biHeight = -height,
+                    biPlanes = 1,
+                    biBitCount = 32,
+                    biCompression = (uint)BI_COMPRESSION.BI_RGB
+                }
+            };
+            void* pixels = null;
+            bitmap = PInvoke.CreateDIBSection(
+                memoryDc,
+                &bitmapInfo,
+                DIB_USAGE.DIB_RGB_COLORS,
+                &pixels,
+                default,
+                0);
+
+            if (bitmap.IsNull || pixels is null)
+            {
+                return false;
+            }
+
+            previousBitmap = PInvoke.SelectObject(memoryDc, bitmap);
+            using var surface = SKSurface.Create(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul), (IntPtr)pixels, width * 4);
+            if (surface is null)
+            {
+                return false;
+            }
+
+            var canvas = surface.Canvas;
+            canvas.Clear(SKColors.Transparent);
+            var frame = new SKRect(padding, padding, width - padding, height - padding);
+            using var roundRect = new SKRoundRect(frame, radius, radius);
+            canvas.Save();
+            canvas.ClipRoundRect(roundRect, SKClipOperation.Difference, antialias: true);
+
+            var sigma = BlurRadiusToSigma(ShadowBlurRadius) * (float)scaling;
+            using var shadowFilter = SKImageFilter.CreateBlur(sigma, sigma);
+            using var shadowPaint = new SKPaint();
+            shadowPaint.IsAntialias = true;
+            shadowPaint.Color = new SKColor(0, 0, 0, shadowAlpha);
+            shadowPaint.ImageFilter = shadowFilter;
+            canvas.DrawRoundRect(roundRect, shadowPaint);
+            canvas.Restore();
+            canvas.Flush();
+
+            var destination = new Point(x, y);
+            var size = new SIZE(width, height);
+            var source = new Point(0, 0);
+            var blend = new BLENDFUNCTION
+            {
+                BlendOp = 0,
+                SourceConstantAlpha = byte.MaxValue,
+                AlphaFormat = 1
+            };
+
+            return PInvoke.UpdateLayeredWindow(
+                _shadow,
+                screenDc,
+                &destination,
+                &size,
+                memoryDc,
+                &source,
+                default,
+                &blend,
+                UPDATE_LAYERED_WINDOW_FLAGS.ULW_ALPHA);
+        }
+        finally
+        {
+            if (!previousBitmap.IsNull)
+            {
+                PInvoke.SelectObject(memoryDc, previousBitmap);
+            }
+
+            if (!bitmap.IsNull)
+            {
+                PInvoke.DeleteObject(bitmap);
+            }
+
+            PInvoke.DeleteDC(memoryDc);
+            PInvoke.ReleaseDC(HWND.Null, screenDc);
+        }
+    }
+
+    private static float BlurRadiusToSigma(float radius) =>
+        radius <= 0 ? 0 : 0.288675f * radius + 0.5f;
+
+    private void Hide()
+    {
+        if (_shadowVisible)
+        {
+            PInvoke.ShowWindow(_shadow, SHOW_WINDOW_CMD.SW_HIDE);
+            _shadowVisible = false;
+        }
+    }
+
+    private void Dispose()
+    {
+        Win32Properties.RemoveWndProcHookCallback(_window, WndProcHookCallback);
+        Win32Properties.RemoveWindowStylesCallback(_window, WindowStylesCallback);
+        DisposeHelper.DisposeToDefault(ref _cornerRadiusOverride);
+        DisposeHelper.DisposeToDefault(ref _borderThicknessOverride);
+        if (!_shadow.IsNull)
+        {
+            PInvoke.DestroyWindow(_shadow);
+            _shadow = HWND.Null;
+        }
+    }
+}

--- a/src/Everywhere.Windows/Interop/ChatWindowShadow.cs
+++ b/src/Everywhere.Windows/Interop/ChatWindowShadow.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.Runtime.CompilerServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Dwm;
@@ -22,6 +23,8 @@ internal sealed class ChatWindowShadow
     private const byte ActiveShadowAlpha = 100;
     private const byte InactiveShadowAlpha = 60;
 
+    private static readonly ConditionalWeakTable<ChatWindow, ChatWindowShadow> Shadows = new();
+
     private readonly ChatWindow _window;
     private readonly HWND _owner;
     private readonly IWindowCornerRadiusFeature _cornerRadiusFeature;
@@ -37,6 +40,7 @@ internal sealed class ChatWindowShadow
     private float _shadowRadius = float.NaN;
     private byte _shadowAlpha;
     private bool _isActive;
+    private bool _isDisposed;
 
     private ChatWindowShadow(ChatWindow window, HWND owner, IWindowCornerRadiusFeature cornerRadiusFeature)
     {
@@ -54,19 +58,36 @@ internal sealed class ChatWindowShadow
             return;
         }
 
+        if (window.TryGetPlatformHandle() is not { } handle)
+        {
+            cornerRadiusFeature.SetCornerRadiusSuppressed(true);
+            return;
+        }
+
+        var owner = (HWND)handle.Handle;
+        if (Shadows.TryGetValue(window, out var existingShadow))
+        {
+            if (existingShadow._owner == owner)
+            {
+                existingShadow.Update();
+                return;
+            }
+
+            existingShadow.Dispose();
+        }
+
         // Fail closed until the shadow HWND and DWM policy have both been established. A later
         // SetCornerRadius call can still store the requested radius without exposing a clipped
         // content-only window.
         cornerRadiusFeature.SetCornerRadiusSuppressed(true);
-        if (window.TryGetPlatformHandle() is not { } handle)
+        var shadow = new ChatWindowShadow(window, owner, cornerRadiusFeature);
+        if (shadow.Attach())
         {
-            return;
+            Shadows.Add(window, shadow);
         }
-
-        new ChatWindowShadow(window, (HWND)handle.Handle, cornerRadiusFeature).Attach();
     }
 
-    private unsafe void Attach()
+    private unsafe bool Attach()
     {
         using var hInstance = PInvoke.GetModuleHandle();
         _shadow = PInvoke.CreateWindowEx(
@@ -86,7 +107,7 @@ internal sealed class ChatWindowShadow
 
         if (_shadow.IsNull)
         {
-            return;
+            return false;
         }
 
         fixed (char* propertyName = "UIA_WindowVisibilityOverridden")
@@ -100,7 +121,7 @@ internal sealed class ChatWindowShadow
         {
             PInvoke.DestroyWindow(_shadow);
             _shadow = HWND.Null;
-            return;
+            return false;
         }
 
         _cornerRadiusFeature.SetNativeFrameRenderingSuppressed(true);
@@ -108,6 +129,7 @@ internal sealed class ChatWindowShadow
         ApplyNativeBehaviorStyles();
         Win32Properties.AddWndProcHookCallback(_window, WndProcHookCallback);
         Update();
+        return true;
     }
 
     private unsafe bool TryDisableNativeFrameRendering()
@@ -441,6 +463,14 @@ internal sealed class ChatWindowShadow
 
     private void Dispose()
     {
+        if (_isDisposed) return;
+        _isDisposed = true;
+
+        if (Shadows.TryGetValue(_window, out var currentShadow) && ReferenceEquals(currentShadow, this))
+        {
+            Shadows.Remove(_window);
+        }
+
         Win32Properties.RemoveWndProcHookCallback(_window, WndProcHookCallback);
         Win32Properties.RemoveWindowStylesCallback(_window, WindowStylesCallback);
         DisposeHelper.DisposeToDefault(ref _cornerRadiusOverride);

--- a/src/Everywhere.Windows/Interop/ChatWindowShadow.cs
+++ b/src/Everywhere.Windows/Interop/ChatWindowShadow.cs
@@ -466,6 +466,8 @@ internal sealed class ChatWindowShadow
         if (_isDisposed) return;
         _isDisposed = true;
 
+        _cornerRadiusFeature.SetNativeFrameRenderingSuppressed(false);
+
         if (Shadows.TryGetValue(_window, out var currentShadow) && ReferenceEquals(currentShadow, this))
         {
             Shadows.Remove(_window);

--- a/src/Everywhere.Windows/Interop/WindowHelper.cs
+++ b/src/Everywhere.Windows/Interop/WindowHelper.cs
@@ -3,7 +3,9 @@ using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Dwm;
 using Windows.Win32.UI.WindowsAndMessaging;
 using Avalonia.Controls;
+using Everywhere.Patches.Contracts.Interop;
 using Everywhere.Interop;
+using Everywhere.Views;
 
 namespace Everywhere.Windows.Interop;
 
@@ -242,8 +244,28 @@ public sealed class WindowHelper : IWindowHelper
         PInvoke.FlashWindowEx(&info);
     }
 
+    public void SetCornerRadius(Window window, double radius)
+    {
+        // ReSharper disable once SuspiciousTypeConversion.Global
+        // This is auto waved into Avalonia.Win32.WindowImpl by MonoMod in project `Everywhere.Patches.Avalonia.Win32`
+        if (window.PlatformImpl is IWindowCornerRadiusFeature feature)
+        {
+            feature.SetCornerRadius(radius);
+            window.InvalidateVisual();
+        }
+
+        // The arbitrary radius is owned by the compositor patch. Disabling DWM's fixed Windows 11
+        // radius also makes the fallback deterministic: an unavailable custom frame remains square.
+        Win32Properties.SetWindowCornerPreference(
+            window,
+            Win32Properties.WindowCornerPreference.DoNotRound);
+    }
+
     public void InitializeWindow(Window window)
     {
-        // Do nothing
+        if (window is ChatWindow chatWindow)
+        {
+            ChatWindowShadow.Attach(chatWindow);
+        }
     }
 }

--- a/src/Everywhere.Windows/NativeMethods.txt
+++ b/src/Everywhere.Windows/NativeMethods.txt
@@ -7,11 +7,14 @@ ShowWindow
 GetWindowLong
 SetWindowLong
 GetWindowRect
+GetClientRect
+ClientToScreen
 WindowFromPoint
 GetAncestor
 IsWindowVisible
 GetWindowPlacement
 SetLayeredWindowAttributes
+UpdateLayeredWindow
 GetForegroundWindow
 SetForegroundWindow
 SetWindowPos
@@ -19,6 +22,8 @@ SetActiveWindow
 IsWindowEnabled
 GetWindow
 IsIconic
+IsZoomed
+IsWindowArranged
 SetFocus
 HWND_BOTTOM
 HWND_TOPMOST
@@ -63,6 +68,11 @@ MonitorFromPoint
 MonitorFromWindow
 GetDC
 ReleaseDC
+CreateCompatibleDC
+DeleteDC
+CreateDIBSection
+SelectObject
+DeleteObject
 GetSystemMetrics
 DwmGetWindowAttribute
 DwmSetWindowAttribute


### PR DESCRIPTION
## Description

Implement custom rounded corners for the chat window across Windows and macOS, using platform-native composition and shadow behavior to match the requested 20-pixel design radius.

The custom frame is disabled when the window is hidden, minimized, maximized, snapped, or fullscreen, ensuring that these native window states retain square edges and correct platform behavior.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation update
- [ ] CI/CD or Build changes

## Current Behavior

The chat window relies on platform-defined window corners, so its native surface does not consistently match the corner radius defined by the application UI.

On Windows, the native compositor and DWM frame cannot directly provide the requested arbitrary radius and matching shadow. On macOS, the acrylic backdrop may also use a material that does not correctly follow the effective appearance and window activation state.

## Updated/Expected Behavior

- The chat window uses a 20-pixel corner radius on supported Windows and macOS compositors.
- Native content, acrylic backdrops, borders, and shadows follow the same rounded geometry.
- Maximized, snapped, fullscreen, minimized, and hidden states suppress the custom frame where appropriate.
- Restoring the window restores its rounded corners and shadow.
- On Windows, the shadow becomes lighter when the window loses activation:
  - Active shadow alpha: `100`
  - Inactive shadow alpha: `60`
- On macOS, the backdrop follows the effective light/dark appearance and active/inactive window state.
- Linux behavior remains unchanged because X11 window shaping does not provide suitable antialiasing.

To test:

1. Open the chat window and verify that its native frame matches the 20-pixel UI corner radius.
2. Resize the window and move it between displays with different scaling factors.
3. Maximize, snap, minimize, enter fullscreen, and restore the window.
4. On Windows, switch focus between the chat window and another window and verify that only the shadow opacity changes.
5. On macOS, verify the backdrop and shadow in light mode, dark mode, and inactive-window states.

Validation:

- `dotnet build Everywhere.Windows.slnx --no-restore`
- Build completed successfully with 0 errors.

## Implementation Details

- Added a platform-level `SetCornerRadius` API to `IWindowHelper`.
- Added a shared patch contract that exposes the requested and effective corner radius to Avalonia's Windows platform implementation.
- Added MonoMod patches for both DirectComposition and WinUI Composition rendering paths:
  - Apply antialiased rounded compositor clips.
  - Keep the acrylic or Mica backdrop inside the rendered border.
  - Update clips when size, scaling, radius, or native window state changes.
- Replaced the Windows DWM frame shadow with a non-activating layered shadow window that follows the custom geometry.
- The Windows shadow listens for `WM_ACTIVATE` and redraws when its active-state alpha changes.
- Added macOS continuous CALayer corners, native shadow invalidation, and semantic backdrop material handling.
- Updated patch build wiring and assembly resolution to support the new Avalonia Win32 patch.
- Kept the Linux implementation as an intentional no-op because X11 shaping would produce non-antialiased corners.
- Updated the chat window spacing and close-button styling to match the new frame.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added XML documentation to any related classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rounded corners and custom window shaping for chat windows across supported desktop platforms.
  * Added enhanced Windows chat window shadows for active and inactive states.
  * Added improved acrylic backdrop behavior on macOS.

* **Style**
  * Refined chat window controls, close-button hover styling, spacing, and input-area layout.
  * Improved window frame behavior during fullscreen, minimized, and hidden states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->